### PR TITLE
Bala/avoid from creating new request object to get the appended `req_id` in deriv.app

### DIFF
--- a/src/deriv_api/SubscriptionManager.js
+++ b/src/deriv_api/SubscriptionManager.js
@@ -50,8 +50,8 @@ export default class SubscriptionManager {
         if (this.sourceExists(request)) {
             return this.getSource(request);
         }
-
-        return this.createNewSource({ ...request, subscribe: 1 });
+        request.subscribe = 1;
+        return this.createNewSource(request);
     }
 
     getSource(request) {


### PR DESCRIPTION
### Changelog
- avoid from creating new request object to get the appended `req_id` in deriv.app