### PR TITLE
Bala/avoid completing empty poc subscription

### DIFF
--- a/src/deriv_api/SubscriptionManager.js
+++ b/src/deriv_api/SubscriptionManager.js
@@ -134,10 +134,16 @@ export default class SubscriptionManager {
         });
     }
 
-    saveSubsId(key, { subscription, msg_type }) {
+    saveSubsId(key, { echo_req, subscription, msg_type }) {
         // If the response doesn't have a subs id, it's not a subscription, so complete source
         // Useful for poc for sold contract which never returns subscription
-        if (!subscription) return this.completeSubsByKey(key);
+        if (!subscription) {
+            // subscribing to proposal open contract without any open positions doesn't send subscription id
+            // We should not complete that subscription in order to receive poc of later
+            if (echo_req && echo_req.subscribe) return undefined;
+
+            return this.completeSubsByKey(key);
+        }
 
         const { id } = subscription;
 

--- a/src/deriv_api/SubscriptionManager.js
+++ b/src/deriv_api/SubscriptionManager.js
@@ -139,7 +139,7 @@ export default class SubscriptionManager {
         // Useful for poc for sold contract which never returns subscription
         if (!subscription) {
             // subscribing to proposal open contract without any open positions doesn't send subscription id
-            // We should not complete that subscription in order to receive poc of later
+            // We should not complete that subscription in order to receive poc of contracts purchased later
             if (echo_req && echo_req.subscribe) return undefined;
 
             return this.completeSubsByKey(key);


### PR DESCRIPTION
### Changelog

- Subscribing to proposal open contract without any open positions doesn't send subscription id. We should not complete that subscription in order to receive poc of contracts purchased later