### PR TITLE
Fixed a bug with the `keep_alive_interval` handler.

### DIFF
--- a/src/deriv_api/DerivAPIBasic.js
+++ b/src/deriv_api/DerivAPIBasic.js
@@ -119,6 +119,10 @@ export default class DerivAPIBasic extends DerivAPICalls {
 
     disconnect() {
         this.shouldReconnect = false; // prevents re-connecting automatically
+        if (this.keep_alive_interval) {
+            clearInterval(this.keep_alive_interval);
+            this.keep_alive_interval = false;
+        }
         this.connection.close();
     }
 


### PR DESCRIPTION
Fixed a bug with the `keep_alive_interval` handler where it was preventing the process from exiting after a graceful shutdown (by calling `.disconnect()` func) was initiated.