### PR TITLE
yashim/feat: add requestDataTransformer middleware functionality

### DIFF
--- a/src/deriv_api/DerivAPIBasic.js
+++ b/src/deriv_api/DerivAPIBasic.js
@@ -148,7 +148,9 @@ export default class DerivAPIBasic extends DerivAPICalls {
         const send_will_be_called = this.callMiddleware('sendWillBeCalled', { args });
         if (send_will_be_called) return send_will_be_called;
 
-        const [request] = args;
+        const [parsed_request] = args;
+
+        const request = this.callMiddleware('requestDataTransformer', parsed_request) || parsed_request;
 
         this.events.next({
             name: 'send',
@@ -178,7 +180,8 @@ export default class DerivAPIBasic extends DerivAPICalls {
         return this.middleware[name](args);
     }
 
-    subscribe(request) {
+    subscribe(parsed_request) {
+        const request = this.callMiddleware('requestDataTransformer', parsed_request) || parsed_request;
         return this.subscription_manager.subscribe(request);
     }
 

--- a/src/deriv_api/__tests__/middleware.js
+++ b/src/deriv_api/__tests__/middleware.js
@@ -36,6 +36,13 @@ test('Expect requestDataTransformer to modify requests', async () => {
     expect(modified_request).toEqual({ ping: 1, modified: true, req_id: 1 });
 });
 
+test('Expect request data to be unchanged if requestDataTransformer is not defined', async () => {
+    delete middleware.requestDataTransformer;
+
+    const returned_value = api.send(request);
+    expect(returned_value).toEqual(Promise.resolve(1));
+});
+
 beforeAll(() => {
     connection = new TestWebSocket({
         ping: 'pong',

--- a/src/deriv_api/__tests__/middleware.js
+++ b/src/deriv_api/__tests__/middleware.js
@@ -5,8 +5,9 @@ let api;
 let connection;
 
 const middleware = {
-    sendWillBeCalled: jest.fn(),
-    sendIsCalled    : jest.fn(),
+    sendWillBeCalled      : jest.fn(),
+    sendIsCalled          : jest.fn(),
+    requestDataTransformer: jest.fn(),
 };
 
 const request = { ping: 1 };
@@ -14,6 +15,7 @@ const request = { ping: 1 };
 test('Expect middleware functions to be called on send', async () => {
     api.send(request);
     expect(middleware.sendWillBeCalled).toBeCalledWith({ args: [request] });
+    expect(middleware.requestDataTransformer).toBeCalledWith(request);
     expect(middleware.sendIsCalled)
         .toBeCalledWith({ response_promise: new Promise(() => {}), args: [request] });
 });
@@ -25,6 +27,13 @@ test('Expect sendIsCalled to be called if sendWillBeCalled returns undefined', a
     const returned_value = api.send(request);
     expect(returned_value).toEqual(Promise.resolve(1));
     expect(middleware.sendIsCalled).not.toBeCalled();
+});
+
+test('Expect requestDataTransformer to modify requests', async () => {
+    middleware.requestDataTransformer = (req) => ({ ...req, modified: true });
+
+    const modified_request = middleware.requestDataTransformer(request);
+    expect(modified_request).toEqual({ ping: 1, modified: true, req_id: 1 });
 });
 
 beforeAll(() => {


### PR DESCRIPTION
- Add `requestDataTransformer()` functionality to DerivAPIBasic
- This function allows user to attach a function to modify request_data on both `send()` and `subscribe()` method
- If no `requestDataTransformer()` is passed, it will just pass through the original request_data
- Updated tests as well