### PR TITLE
feat: add option to exclude from request block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@deriv/deriv-api",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@deriv/deriv-api",
-      "version": "1.0.14",
+      "version": "1.0.15",
       "license": "MIT",
       "dependencies": {
         "dayjs": "^1.11.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deriv/deriv-api",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Websocket API for Deriv applications",
   "main": "dist/DerivAPI.js",
   "unpkg": "dist/DerivAPI.js",


### PR DESCRIPTION
## Description
- Add option to exclude certain api types from request block
- Defaults to `website_status` and `authorize` if not specified